### PR TITLE
Add real museum reference fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ An OpenAI-powered multi-agent system designed to help historical reenactors buil
 - **Persona Selector Agent**: Helps users narrow down their historical role (e.g., 14th-century French archer, 15th-century English knight).
 - **Kit Recommender Agent**: Generates a detailed gear list based on selected persona.
 - **Reference Finder Agent**: Finds museum artifacts and period illustrations for each piece of gear.
+- **Reference Sources**: Pulls images directly from museum APIs such as the Metropolitan Museum of Art and the Royal Armouries.
 - **Vendor Finder Agent**: Recommends respected, community-endorsed vendors or searches for options when no known supplier is found.
 
 ---

--- a/reenactment_agent/README.md
+++ b/reenactment_agent/README.md
@@ -9,6 +9,7 @@ An OpenAI-powered multi-agent system designed to help historical reenactors buil
 - **Persona Selector Agent**: Helps users narrow down their historical role (e.g., 14th-century French archer, 15th-century English knight).
 - **Kit Recommender Agent**: Generates a detailed gear list based on selected persona.
 - **Reference Finder Agent**: Finds museum artifacts and period illustrations for each piece of gear.
+- **Reference Sources**: Pulls images directly from museum APIs such as the Metropolitan Museum of Art and the Royal Armouries.
 - **Vendor Finder Agent**: Recommends respected, community-endorsed vendors or searches for options when no known supplier is found.
 
 ---

--- a/reenactment_agent/tools/fetch_references.py
+++ b/reenactment_agent/tools/fetch_references.py
@@ -1,3 +1,88 @@
+"""Utility for pulling reference images from museum APIs."""
+
+from __future__ import annotations
+
+import logging
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+def _search_met(item: str) -> dict[str, str] | None:
+    """Search the Metropolitan Museum of Art collection API."""
+    search_url = "https://collectionapi.metmuseum.org/public/collection/v1/search"
+    try:
+        resp = requests.get(search_url, params={"q": item, "hasImages": True}, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception as exc:  # pragma: no cover - network call
+        logger.warning("MET search failed: %s", exc)
+        return None
+
+    ids = data.get("objectIDs")
+    if not ids:
+        return None
+
+    object_url = f"https://collectionapi.metmuseum.org/public/collection/v1/objects/{ids[0]}"
+    try:
+        resp = requests.get(object_url, timeout=10)
+        resp.raise_for_status()
+        obj = resp.json()
+    except Exception as exc:  # pragma: no cover - network call
+        logger.warning("MET object retrieval failed: %s", exc)
+        return None
+
+    image = obj.get("primaryImageSmall") or obj.get("primaryImage")
+    if not image:
+        return None
+
+    return {
+        "image_url": image,
+        "museum": "Metropolitan Museum of Art",
+    }
+
+
+def _search_royal_armories(item: str) -> dict[str, str] | None:
+    """Search the Royal Armouries collection API."""
+    search_url = "https://collectionapi.royalarmouries.org/objects/search"
+    try:
+        resp = requests.get(search_url, params={"q": item, "pageSize": 1}, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception as exc:  # pragma: no cover - network call
+        logger.warning("Royal Armouries search failed: %s", exc)
+        return None
+
+    items = data.get("data")
+    if not items:
+        return None
+
+    obj = items[0]
+    attributes = obj.get("attributes", {})
+    image = attributes.get("imageThumbURL") or attributes.get("imageUrl")
+    if not image:
+        return None
+
+    return {
+        "image_url": image,
+        "museum": "Royal Armouries",
+    }
+
+
 def fetch_references(item: str) -> dict:
-    """Return fake reference data."""
-    return {"image_url": "http://example.com/image.jpg", "museum": "Example Museum"}
+    """Return reference image information for ``item``.
+
+    The function attempts to query several museum APIs for the first
+    available image. Currently supported sources are the Metropolitan
+    Museum of Art and the Royal Armouries. If no result is found, an empty
+    dictionary is returned.
+    """
+
+    for search_func in (_search_met, _search_royal_armories):
+        result = search_func(item)
+        if result:
+            return result
+
+    logger.info("No reference found for '%s'", item)
+    return {"image_url": "", "museum": ""}


### PR DESCRIPTION
## Summary
- use museum APIs in `fetch_references`
- document external museum sources

## Testing
- `ruff format reenactment_agent/tools/fetch_references.py`
- `ruff check reenactment_agent/tools/fetch_references.py`
- `pytest -q` *(fails: 0 tests run)*
- `make format` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684479c602ac8322a86c1ca8a30c2b32