### PR TITLE
Add reference image download zip

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,15 +1,56 @@
 from fastapi import FastAPI
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 from reenactment_agent.runner import run_pipeline
+import io
+import zipfile
+import requests
 
 class PipelineRequest(BaseModel):
     century: str
     region: str
     role: str
 
+
+class ZipRequest(BaseModel):
+    references: dict[str, dict[str, str]]
+
 app = FastAPI()
+
+
+def _categorize_item(name: str) -> str:
+    lowered = name.lower()
+    if any(k in lowered for k in ["helm", "hat", "coif", "head"]):
+        return "head"
+    if any(k in lowered for k in ["breast", "cuirass", "torso", "chest", "armor"]):
+        return "chest"
+    if any(k in lowered for k in ["leg", "chauss", "greave", "pant"]):
+        return "legs"
+    return "misc"
 
 @app.post("/api/pipeline")
 def pipeline(req: PipelineRequest):
     """Run the reenactment pipeline and return results."""
     return run_pipeline(req.century, req.region, req.role)
+
+
+@app.post("/api/references_zip")
+def references_zip(req: ZipRequest):
+    """Download reference images and return a zip archive."""
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as zf:
+        for item, ref in req.references.items():
+            url = ref.get("image_url")
+            if not url:
+                continue
+            try:
+                resp = requests.get(url, timeout=10)
+                resp.raise_for_status()
+            except Exception:
+                continue
+            category = _categorize_item(item)
+            ext = url.split(".")[-1].split("?")[0]
+            filename = f"{category}/{item.replace(' ', '_')}.{ext}"
+            zf.writestr(filename, resp.content)
+    buffer.seek(0)
+    return StreamingResponse(buffer, media_type="application/zip", headers={"Content-Disposition": "attachment; filename=references.zip"})

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -16,6 +16,23 @@ function App() {
     setResult(data);
   };
 
+  const downloadZip = async () => {
+    if (!result) return;
+    const resp = await fetch('/api/references_zip', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ references: result.references })
+    });
+    const blob = await resp.blob();
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'references.zip';
+    a.click();
+    a.remove();
+    window.URL.revokeObjectURL(url);
+  };
+
   return (
     <div>
       <h1>Reenactment Kit Builder</h1>
@@ -23,7 +40,18 @@ function App() {
       <input placeholder="Region" value={region} onChange={e => setRegion(e.target.value)} />
       <input placeholder="Role" value={role} onChange={e => setRole(e.target.value)} />
       <button onClick={runPipeline}>Build Kit</button>
-      {result && <pre>{JSON.stringify(result, null, 2)}</pre>}
+      {result && (
+        <div>
+          {Object.entries(result.references).map(([item, ref]) => (
+            <div key={item}>
+              <p>{item} ({ref.museum})</p>
+              {ref.image_url && <img src={ref.image_url} alt={item} style={{ maxWidth: '200px' }} />}
+            </div>
+          ))}
+          <button onClick={downloadZip}>Download Images</button>
+          <pre>{JSON.stringify(result, null, 2)}</pre>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- allow downloading kit reference images in a zip archive
- show images from the reference finder in the frontend

## Test plan
- `make format` *(fails: rich download unsuccessful)*
- `make lint` *(fails: markdown download unsuccessful)*
- `make tests` *(fails: rich download unsuccessful)*

------
https://chatgpt.com/codex/tasks/task_e_684483a26d788322956fabf521306ac3