### PR TITLE
Implement basic tool logic

### DIFF
--- a/reenactment_agent/tools/generate_kit.py
+++ b/reenactment_agent/tools/generate_kit.py
@@ -1,3 +1,46 @@
+"""Generate a very small kit list based on the persona description."""
+
+from __future__ import annotations
+
+
+def _kit_for_role(role: str) -> list[str]:
+    """Return common equipment for the given role."""
+
+    role = role.lower()
+    if "archer" in role:
+        return [
+            "longbow",
+            "quiver of arrows",
+            "gambeson",
+            "belt pouch",
+            "leather boots",
+        ]
+    if "knight" in role:
+        return [
+            "helmet",
+            "breastplate",
+            "gauntlets",
+            "sword",
+            "shield",
+        ]
+    if "pikeman" in role or "infantry" in role:
+        return [
+            "pikestaff",
+            "helmet",
+            "gambeson",
+            "belt",
+        ]
+    # Generic fallback
+    return [
+        "tunic",
+        "belt",
+        "knife",
+    ]
+
+
 def generate_kit_list(persona: str) -> list[str]:
-    """Return a placeholder kit list."""
-    return [f"Item for {persona} 1", f"Item for {persona} 2"]
+    """Return a list of historical gear items for ``persona``."""
+
+    role_part = persona.lower()
+    kit = _kit_for_role(role_part)
+    return kit

--- a/reenactment_agent/tools/recommend_suppliers.py
+++ b/reenactment_agent/tools/recommend_suppliers.py
@@ -1,3 +1,32 @@
+"""Simple supplier recommender used by the demo frontend."""
+
+from __future__ import annotations
+
+
+_SUPPLIER_MAP: dict[str, list[str]] = {
+    "longbow": ["Traditional Archery Supply", "Woodland Longbows"],
+    "quiver": ["Traditional Archery Supply"],
+    "helmet": ["Age of Craft", "Kult of Athena"],
+    "breastplate": ["Medieval Armoury"],
+    "sword": ["Albion Swords", "Kult of Athena"],
+    "shield": ["Kult of Athena"],
+    "gambeson": ["Historic Enterprises"],
+}
+
+
 def recommend_suppliers(item: str) -> list[str]:
-    """Return placeholder supplier list."""
-    return ["Supplier A", "Supplier B"]
+    """Return a list of supplier names for ``item``.
+
+    If the item is not known, a short list of generic suggestions is
+    returned to encourage the user to continue their own search.
+    """
+
+    lowered = item.lower()
+    for key, suppliers in _SUPPLIER_MAP.items():
+        if key in lowered:
+            return suppliers
+
+    return [
+        "Check with local reenactment groups",
+        "Search online specialty vendors",
+    ]

--- a/reenactment_agent/tools/suggest_persona.py
+++ b/reenactment_agent/tools/suggest_persona.py
@@ -1,3 +1,42 @@
+"""Utility functions for suggesting a reenactment persona."""
+
+from __future__ import annotations
+
+import re
+
+
+def _format_century(value: str) -> str:
+    """Normalize a century string to an ordinal form.
+
+    Parameters
+    ----------
+    value
+        The user provided century value which may be a plain number
+        (``"15"`` or ``15``) or already contain a suffix such as ``"15th"``.
+    """
+
+    digits = re.match(r"(\d+)", str(value).strip())
+    if not digits:
+        return value.strip()
+
+    number = int(digits.group(1))
+    if 11 <= number % 100 <= 13:
+        suffix = "th"
+    else:
+        suffix = {1: "st", 2: "nd", 3: "rd"}.get(number % 10, "th")
+    return f"{number}{suffix}"
+
+
 def suggest_persona(century: str, region: str, role: str) -> str:
-    """Return a basic persona string."""
-    return f"{century} century {region} {role}"
+    """Return a formatted persona description.
+
+    The function tries to clean up the provided values so that the
+    resulting string is easy to read and consistent. This helps the
+    frontend display a reasonable suggestion without having to rely on
+    an LLM call.
+    """
+
+    century_formatted = _format_century(century)
+    region_formatted = region.strip().title()
+    role_formatted = role.strip().lower()
+    return f"{century_formatted}-century {region_formatted} {role_formatted}"


### PR DESCRIPTION
## Summary
- flesh out stub tool functions used by the demo
  - format persona strings
  - create small kit lists from persona role
  - supply vendor suggestions for common items

## Testing
- `ruff format reenactment_agent/tools/suggest_persona.py reenactment_agent/tools/generate_kit.py reenactment_agent/tools/recommend_suppliers.py`
- `ruff check reenactment_agent/tools/suggest_persona.py reenactment_agent/tools/generate_kit.py reenactment_agent/tools/recommend_suppliers.py`
- `mypy reenactment_agent/tools/suggest_persona.py reenactment_agent/tools/generate_kit.py reenactment_agent/tools/recommend_suppliers.py`


------
https://chatgpt.com/codex/tasks/task_e_68448d07ef848322a108e249ec62c546