### PR TITLE
Add OPENAI_API_KEY config

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,17 @@ app.py                             # FastAPI server
 pip install fastapi uvicorn openai pydantic openai-agents
 ```
 
-2. **Start the API server**:
+2. **Set your OpenAI API key**:
+```bash
+export OPENAI_API_KEY=your-key-here
+```
+
+3. **Start the API server**:
 ```bash
 uvicorn app:app --reload
 ```
 
-3. **Start the React frontend**:
+4. **Start the React frontend**:
 ```bash
 cd frontend && npm install && npm start
 ```

--- a/app.py
+++ b/app.py
@@ -1,3 +1,6 @@
+import os
+
+import openai
 from fastapi import FastAPI
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
@@ -14,6 +17,8 @@ class PipelineRequest(BaseModel):
 
 class ZipRequest(BaseModel):
     references: dict[str, dict[str, str]]
+
+openai.api_key = os.getenv("OPENAI_API_KEY")
 
 app = FastAPI()
 

--- a/reenactment_agent/README.md
+++ b/reenactment_agent/README.md
@@ -46,7 +46,12 @@ reenactment_agent/
 pip install openai pydantic
 ```
 
-2. **Run the system**:
+2. **Set your OpenAI API key**:
+```bash
+export OPENAI_API_KEY=your-key-here
+```
+
+3. **Run the system**:
 ```bash
 python runner.py
 ```

--- a/reenactment_agent/runner.py
+++ b/reenactment_agent/runner.py
@@ -1,9 +1,14 @@
 # runner.py
+import os
+
+import openai
 from agents import Runner
 from .agents.persona_selector import persona_selector_agent
 from .agents.kit_recommender_agent import kit_recommender_agent
 from .agents.reference_finder_agent import reference_finder_agent
 from .agents.supplier_recommender_agent import supplier_recommender_agent
+
+openai.api_key = os.getenv("OPENAI_API_KEY")
 
 
 def run_pipeline(century: str, region: str, role: str):


### PR DESCRIPTION
## Summary
- mention OPENAI_API_KEY in the docs
- require the key in runner and API server

## Testing
- `make lint` *(fails: failed to download packages)*
- `make tests` *(fails: failed to download packages)*

------
https://chatgpt.com/codex/tasks/task_e_684b7d6ab5448322a48b59b8914ac741